### PR TITLE
Add GCP credentials handling in Firebase workflow and update .gitignore

### DIFF
--- a/.github/workflows/deployment-firebase-functions-prod.yml
+++ b/.github/workflows/deployment-firebase-functions-prod.yml
@@ -34,6 +34,20 @@ jobs:
           echo "};" >> awsSecret.ts
           cd ../../../..
 
+      - name: Create GCP Credentials File
+        run: |
+          cd backend/functions/src/provider
+          echo "export const gcpCredentials = {" > gcpSecret.ts
+          echo "  type: 'service_account'," >> gcpSecret.ts
+          echo "  project_id: '${{vars.PROJECT_ID}}'," >> gcpSecret.ts
+          echo "  private_key_id: '${{secrets.GCP_PRIVATE_KEY_ID}}'," >> gcpSecret.ts
+          echo "  private_key: '${{secrets.GCP_PRIVATE_KEY}}'," >> gcpSecret.ts
+          echo "  client_email: '${{secrets.GCP_SERVICE_ACCOUNT}}'," >> gcpSecret.ts
+          echo "  client_id: '${{secrets.GCP_CLIENT_ID}}'," >> gcpSecret.ts
+          echo "  universe_domain: 'googleapis.com'," >> gcpSecret.ts
+          echo "};" >> gcpSecret.ts
+          cd ../../../..      
+
       - name: Prepare Google Deployment Credentials
         run: |
           cd backend

--- a/backend/functions/.gitignore
+++ b/backend/functions/.gitignore
@@ -11,3 +11,4 @@ node_modules/
 
 # Secret files
 src/provider/awsSecret.ts
+src/provider/gcpSecret.ts

--- a/backend/functions/src/provider/gcp.ts
+++ b/backend/functions/src/provider/gcp.ts
@@ -1,5 +1,6 @@
 import {TCredentialsGCP, TErrorMessage} from '../types';
 import {GoogleAuth} from 'google-auth-library';
+import {gcpCredentials} from './gcpSecret';
 
 /**
  * Represents the result of a token generation process.
@@ -27,6 +28,7 @@ export async function getImpersonatedToken(credentials: TCredentialsGCP): Promis
   // Create the authentication client
   const authClient = new GoogleAuth({
     scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+    credentials: gcpCredentials,
   });
   // Create the request client
   const client = await authClient.getClient();


### PR DESCRIPTION
- Included GCP secrets generation in `deployment-firebase-functions-prod.yml` for secure handling.
- Updated `.gitignore` to exclude `gcpSecret.ts` file.